### PR TITLE
Add ClusterComponent for identifying the type of certificate.

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -3,6 +3,7 @@ package certificatetpr
 type Spec struct {
 	AllowBareDomains bool     `json:"allowBareDomains" yaml:"allowBareDomains"`
 	AltNames         []string `json:"altNames" yaml:"altNames"`
+	ClusterComponent string   `json:"clusterComponent" yaml:"clusterComponent"`
 	ClusterID        string   `json:"clusterID" yaml:"clusterID"`
 	CommonName       string   `json:"commonName" yaml:"commonName"`
 	IPSANs           []string `json:"ipSans" yaml:"ipSans"`


### PR DESCRIPTION
Towards giantswarm/giantswarm#1255 

This PR adds ClusterComponent to the TPR. This is to identify the type of certificate and will be provided by kubernetesd. The cert-operator will use it to label the k8s secrets it creates.