### PR TITLE
Add module for TLS assets

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4809645913ce6e57a8db18216d2fde7cef0d24f36c90de6ce4e988966914a3ce
-updated: 2017-03-23T12:11:15.997702172+01:00
+hash: 7ba20a61e377d0bdf5357dff237d2a71710c4264f311882018936dd634384a0f
+updated: 2017-03-29T11:15:28.145955349+02:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
@@ -124,4 +124,13 @@ imports:
   - pkg/util/yaml
   - pkg/watch
   - pkg/watch/versioned
-testImports: []
+testImports:
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  repo: git://github.com/stretchr/testify.git
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,9 @@ import:
   subpackages:
   - pkg/api/unversioned
   - pkg/api/v1
+testImport:
+- package: github.com/stretchr/testify
+  version: v1.1.4
+  repo: git://github.com/stretchr/testify.git
+  subpackages:
+  - assert

--- a/tls_assets.go
+++ b/tls_assets.go
@@ -1,0 +1,69 @@
+package certificatetpr
+
+// ClusterComponent represents the individual component of a k8s cluster, e.g. the API server, or etcd
+// These are used when getting a secret from the k8s API, to identify the component the secret belongs to
+type ClusterComponent string
+
+// TLSAssetType represents the type of TLS asset, e.g. a CA certificate, or a certificate key
+// These are used when getting a secret from the k8s API, to identify the specific type of TLS asset that is contained in the secret
+type TLSAssetType string
+
+// These constants are used to match each asset in the secret
+const (
+	// CA is the key for the CA certificate
+	CA TLSAssetType = "ca"
+	// Crt is the key for the certificate
+	Crt TLSAssetType = "crt"
+	// Key is the key for the key
+	Key TLSAssetType = "key"
+)
+
+// These constants are used to match different components of the cluster when parsing a secret received from the API
+const (
+	// APIComponent is the API server
+	APIComponent ClusterComponent = "api"
+	// WorkerComponent is a worker
+	WorkerComponent ClusterComponent = "worker"
+	// EtcdComponent is the etcd cluster
+	EtcdComponent ClusterComponent = "etcd"
+	// CalicoComponent is the calico component
+	CalicoComponent ClusterComponent = "calico"
+)
+
+// These constants are used when filtering the secrets, to only retrieve the ones we are interested in
+const (
+	// ComponentLabel is the label used in the secret to identify a cluster component
+	ComponentLabel string = "clusterComponent"
+	// ClusterIDLabel is the label used in the secret to identify a cluster
+	ClusterIDLabel string = "clusterID"
+)
+
+// AssetsBundle is a structure that contains all the assets for all the components
+type AssetsBundle map[ClusterComponent]map[TLSAssetType][]byte
+
+// ClusterComponents is a slice enumerating all the components that make up the cluster
+var ClusterComponents = []ClusterComponent{APIComponent, WorkerComponent, EtcdComponent, CalicoComponent}
+
+// TLSAssetTypes is a slice enumerating all the TLS assets we need to boot the cluster
+var TLSAssetTypes = []TLSAssetType{CA, Crt, Key}
+
+// ValidComponent looks for el among the components
+func ValidComponent(el ClusterComponent, components []ClusterComponent) bool {
+	for _, v := range components {
+		if el == v {
+			return true
+		}
+	}
+	return false
+}
+
+// NewAssetsBundle initializes the nested map that contains the TLS assets for all the components
+func NewAssetsBundle() AssetsBundle {
+	bundle := make(map[ClusterComponent]map[TLSAssetType][]byte, len(ClusterComponents))
+
+	for k := range bundle {
+		bundle[k] = make(map[TLSAssetType][]byte, len(TLSAssetTypes))
+	}
+
+	return bundle
+}

--- a/tls_assets_test.go
+++ b/tls_assets_test.go
@@ -1,0 +1,45 @@
+package certificatetpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidComponent(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []ClusterComponent
+		el         ClusterComponent
+		res        bool
+	}{
+		{
+			name: "el is present",
+			components: []ClusterComponent{
+				ClusterComponent("foobar"),
+			},
+			el:  ClusterComponent("foobar"),
+			res: true,
+		},
+		{
+			name: "el is not present",
+			components: []ClusterComponent{
+				ClusterComponent("foo"),
+			},
+			el:  ClusterComponent("bar"),
+			res: false,
+		},
+		{
+			name:       "components is empty",
+			components: []ClusterComponent{},
+			el:         ClusterComponent("foobar"),
+			res:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		res := ValidComponent(tc.el, tc.components)
+
+		assert.Equal(t, tc.res, res)
+	}
+}


### PR DESCRIPTION
This module contains constants, variables and functions related to the TLS assets we need to boot up the cluster.

This PR is a port of https://github.com/giantswarm/awstpr/pull/14, and closes it.