### PR TITLE
Fix panic when accessing AssetsBundle map

### DIFF
--- a/tls_assets.go
+++ b/tls_assets.go
@@ -38,8 +38,15 @@ const (
 	ClusterIDLabel string = "clusterID"
 )
 
+// AssetsBundleKey is a struct key for an AssetsBundle
+// cfr. https://blog.golang.org/go-maps-in-action
+type AssetsBundleKey struct {
+	Component ClusterComponent
+	Type      TLSAssetType
+}
+
 // AssetsBundle is a structure that contains all the assets for all the components
-type AssetsBundle map[ClusterComponent]map[TLSAssetType][]byte
+type AssetsBundle map[AssetsBundleKey][]byte
 
 // ClusterComponents is a slice enumerating all the components that make up the cluster
 var ClusterComponents = []ClusterComponent{APIComponent, WorkerComponent, EtcdComponent, CalicoComponent}
@@ -55,15 +62,4 @@ func ValidComponent(el ClusterComponent, components []ClusterComponent) bool {
 		}
 	}
 	return false
-}
-
-// NewAssetsBundle initializes the nested map that contains the TLS assets for all the components
-func NewAssetsBundle() AssetsBundle {
-	bundle := make(map[ClusterComponent]map[TLSAssetType][]byte, len(ClusterComponents))
-
-	for _, c := range ClusterComponents {
-		bundle[c] = make(map[TLSAssetType][]byte, len(TLSAssetTypes))
-	}
-
-	return bundle
 }

--- a/tls_assets.go
+++ b/tls_assets.go
@@ -61,8 +61,8 @@ func ValidComponent(el ClusterComponent, components []ClusterComponent) bool {
 func NewAssetsBundle() AssetsBundle {
 	bundle := make(map[ClusterComponent]map[TLSAssetType][]byte, len(ClusterComponents))
 
-	for k := range bundle {
-		bundle[k] = make(map[TLSAssetType][]byte, len(TLSAssetTypes))
+	for _, c := range ClusterComponents {
+		bundle[c] = make(map[TLSAssetType][]byte, len(TLSAssetTypes))
 	}
 
 	return bundle


### PR DESCRIPTION
[This `for` loop](https://github.com/giantswarm/certificatetpr/blob/90b901bc8a67beee6ac3e87819527e9b9d705031/tls_assets.go#L64) was running 0 times, because the `make` call above was not creating any actual element.

That means that when accessing the nested map, we were running into a `panic`, because it hadn't been initialized (thanks @iaguis ).

We remove the nested map altogether by using a `struct` key. Cfr. [this article](https://blog.golang.org/go-maps-in-action).

This means `AssetsBundle` is a simple `map`, and it can be created with `make`, therefore we also remove the `NewAssetsBundle` function.