### PR TITLE
Update TPR to match the example in client-go to fix decoding errors 

### DIFF
--- a/custom_object.go
+++ b/custom_object.go
@@ -1,15 +1,45 @@
 package certificatetpr
 
 import (
+	"encoding/json"
+
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/meta"
 	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 // CustomObject represents the Certificate TPR's custom object. It holds the
 // specifications of the resource the Certificate operator is interested in.
 type CustomObject struct {
 	unversioned.TypeMeta `json:",inline"`
-	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Metadata             api.ObjectMeta `json:"metadata"`
 
 	Spec Spec `json:"spec" yaml:"spec"`
+}
+
+// GetObjectKind is required to satisfy the Object interface.
+func (c *CustomObject) GetObjectKind() unversioned.ObjectKind {
+	return &c.TypeMeta
+}
+
+// GetObjectMeta is required to satisfy the ObjectMetaAccessor interface.
+func (c *CustomObject) GetObjectMeta() meta.Object {
+	return &c.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type CustomObjectCopy CustomObject
+
+func (c *CustomObject) UnmarshalJSON(data []byte) error {
+	tmp := CustomObjectCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := CustomObject(tmp)
+	*c = tmp2
+	return nil
 }

--- a/list.go
+++ b/list.go
@@ -1,12 +1,42 @@
 package certificatetpr
 
 import (
+	"encoding/json"
+
 	"k8s.io/client-go/pkg/api/unversioned"
 )
 
+// List represents a list of CustomObject resources.
 type List struct {
 	unversioned.TypeMeta `json:",inline"`
-	unversioned.ListMeta `json:"metadata,omitempty"`
+	Metadata             unversioned.ListMeta `json:"metadata"`
 
-	Items []*CustomObject `json:"items"`
+	Items []CustomObject `json:"items"`
+}
+
+// GetObjectKind is required to satisfy the Object interface.
+func (l *List) GetObjectKind() unversioned.ObjectKind {
+	return &l.TypeMeta
+}
+
+// GetListMeta is required to satisfy the ListMetaAccessor interface.
+func (l *List) GetListMeta() unversioned.List {
+	return &l.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type ListCopy List
+
+func (l *List) UnmarshalJSON(data []byte) error {
+	tmp := ListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := List(tmp)
+	*l = tmp2
+	return nil
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1371 and giantswarm/cert-operator#32

When deployed to AWS the cert-operator isn't deleting the k8s secrets it creates because a decoding error is appearing in the logs when the TPO is deleted.

```
streamwatcher.go:109] Unable to decode an event from the watch stream: json: cannot unmarshal string into Go value of type struct { Type watch.EventType; Object certificatetpr.CustomObject }
```
Based on https://github.com/kubernetes/client-go/issues/8 this PR updates the TPR to match the example in the v2.0.0. branch which includes a workaround for problems with ugorji decoding.

https://github.com/kubernetes/client-go/blob/release-2.0/examples/third-party-resources/types.go