### PR TITLE
Add missing yaml attributes to structs

### DIFF
--- a/custom_object.go
+++ b/custom_object.go
@@ -12,7 +12,7 @@ import (
 // specifications of the resource the Certificate operator is interested in.
 type CustomObject struct {
 	unversioned.TypeMeta `json:",inline"`
-	Metadata             api.ObjectMeta `json:"metadata"`
+	Metadata             api.ObjectMeta `json:"metadata" yaml:"metadata"`
 
 	Spec Spec `json:"spec" yaml:"spec"`
 }

--- a/list.go
+++ b/list.go
@@ -9,9 +9,9 @@ import (
 // List represents a list of CustomObject resources.
 type List struct {
 	unversioned.TypeMeta `json:",inline"`
-	Metadata             unversioned.ListMeta `json:"metadata"`
+	Metadata             unversioned.ListMeta `json:"metadata" yaml:"metadata"`
 
-	Items []CustomObject `json:"items"`
+	Items []CustomObject `json:"items" yaml:"items"`
 }
 
 // GetObjectKind is required to satisfy the Object interface.


### PR DESCRIPTION
Towards giantswarm/cert-operator#32

The Spec struct had yaml support but it was missing from CustomObject and List. This fixes that and is part of making sure that the TPOs are decoded correctly.