### PR TITLE
Remove nodecontroller from required components

### DIFF
--- a/tls_assets.go
+++ b/tls_assets.go
@@ -73,7 +73,6 @@ var ClusterComponents = []ClusterComponent{
 	WorkerComponent,
 	EtcdComponent,
 	CalicoComponent,
-	NodeControllerComponent,
 	ServiceAccountComponent,
 }
 
@@ -102,9 +101,6 @@ type CompactTLSAssets struct {
 	EtcdServerCA      string
 	EtcdServerKey     string
 	EtcdServerCrt     string
-	NodeControllerCA  string
-	NodeControllerKey string
-	NodeControllerCrt string
 	ServiceAccountCA  string
 	ServiceAccountKey string
 	ServiceAccountCrt string


### PR DESCRIPTION
Problem is that SearchCerts tries to find all known certs
in default namespace. But node controller lives in sepatate
namespace, moreover we don't have inforamation about TPO.

This change is not propoer solution for SearchCerts. But overall we need to
rethink SearchCerts one more time, looks like certtificatetpr
is not the proper place for such specific busness logic.